### PR TITLE
Add menu support

### DIFF
--- a/src/org/boncey/lcdjava/AbstractMenuItem.java
+++ b/src/org/boncey/lcdjava/AbstractMenuItem.java
@@ -1,0 +1,164 @@
+package org.boncey.lcdjava;
+
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+import javax.swing.event.EventListenerList;
+
+
+/**
+ * Abstract parent class for menu items.
+ * @author Stefan Krupop
+ */
+public abstract class AbstractMenuItem implements MenuItem
+{
+    /** 
+     * The item id.
+     */
+    protected final String _id;
+    
+    /** 
+     * The item text.
+     */
+    private String _text;
+
+    /** 
+     * The menu this item belongs to.
+     */
+    protected Submenu _menu;
+    
+    /** 
+     * The event listeners connected to this item
+     */
+    protected EventListenerList _listeners;
+
+    /**
+     * Constructor.
+     * @param id the of the item.
+     * @param menu the menu to add this item to
+     */
+    protected AbstractMenuItem(String id, Submenu menu)
+    {
+        _id = id;
+        _menu = menu;
+        _listeners = new EventListenerList();
+    }
+
+    /** 
+     * Get the item id.
+     * @return the item id.
+     */
+    public String getID()
+    {
+        return _id;
+    }
+    
+    /**
+     * Set the menu item text.
+     * @param text the menu item text.
+     */
+    public void setText(String text)
+    {
+        _text = text;
+        update();
+    }
+
+    /** 
+     * Get the menu item text.
+     * @return the menu item text.
+     */
+    public String getText()
+    {
+        return _text;
+    }
+
+    /** 
+     * Add this MenuItem to the Submenu that constructed us.
+     * @return whether or not the menu item was added successfully.
+     */
+    public boolean activate()
+    {
+        return _menu.addItem(this);
+    }
+
+    /** 
+     * Remove this MenuItem from the Screen that constructed us.
+     */
+    public void remove()
+    {
+        _menu.removeItem(this);
+    }
+
+    /** 
+     * Strip any quotes from the provided text.
+     * @param text the text to strip quotes from.
+     * @return the text with any quotes removed.
+     */
+    protected String stripQuotes(String text)
+    {
+        StringBuffer ret = new StringBuffer();
+        if (text != null)
+        {
+            char[] chars = text.toCharArray();
+            for (int i = 0; i < chars.length; i++)
+            {
+                if (chars[i] != '\"')
+                {
+                    ret.append(chars[i]);
+                }
+            }
+        }
+        return (text == null) ? null : ret.toString();
+    }
+
+    /** 
+     * Update this MenuItems's state.
+     */
+    protected void update()
+    {
+        _menu.updateItem(this);
+    }
+    
+    /** 
+     * Return the data this menu item needs to update itself.
+     * @return the data to update this menu item.
+     */
+    public String getData()
+    {
+        return "-text \"" + stripQuotes(_text) + "\"";
+    }
+
+    /**
+     * Adds an ActionListener to the menu item.
+     * @param listener the ActionListener to be added
+     */
+	public void addActionListener(ActionListener listener) {
+		_listeners.add(ActionListener.class, listener);
+	}
+
+	/**
+	 * Removes an ActionListener from the menu item.
+	 * @param listener the ActionListener to be removed
+	 */
+	public void removeActionListener(ActionListener listener) {
+		_listeners.remove(ActionListener.class, listener);
+	}
+    
+    public void notifyActionPerformed(ActionEvent e) {
+		for (ActionListener l : _listeners.getListeners(ActionListener.class)) {
+			l.actionPerformed(e);
+		}
+    }
+    
+    /**
+     * Return a String representing this MenuItem.
+     * @return a String representing this MenuItem.
+     */
+    public String toString()
+    {
+        return "Type = " + getType() +
+               "; menu id = " + _menu.getID() +
+               "; id = " + getID() +
+               "; data = " + getData();
+    }
+}

--- a/src/org/boncey/lcdjava/ActionMenuItem.java
+++ b/src/org/boncey/lcdjava/ActionMenuItem.java
@@ -57,7 +57,7 @@ public class ActionMenuItem extends AbstractMenuItem
 
     /**
      * Sets what to do with the menu when this action is selected
-     * @param result
+     * @param result the MenuResult
      */
     public void setMenuResult(MenuResult result) {
     	_menuResult = result;
@@ -84,6 +84,7 @@ public class ActionMenuItem extends AbstractMenuItem
      * Construct a new ActionMenuItem.
      * @param menu the Submenu that owns the menu item.
      * @param text the menu text.
+     * @param result the MenuResult defining what to do when action is selected
      * @return a new ActionMenuItem.
      */
     public static ActionMenuItem construct(Submenu menu, String text, MenuResult result)

--- a/src/org/boncey/lcdjava/ActionMenuItem.java
+++ b/src/org/boncey/lcdjava/ActionMenuItem.java
@@ -1,0 +1,129 @@
+package org.boncey.lcdjava;
+
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+
+
+/**
+ * ActionMenuItem.
+ * <p>Item to trigger an action
+ * @author StefanKrupop
+ */
+public class ActionMenuItem extends AbstractMenuItem 
+{
+	public enum MenuResult {
+		/**
+		 * Menu stays as it is
+		 */
+		None("none"),
+		/**
+		 * Menu closes and returns to a higher level
+		 */
+		Close("close"),
+		/**
+		 * Quits the menu completely
+		 */
+		Quit("quit");
+		
+		public String val;
+		
+		MenuResult(String val) {
+			this.val = val;
+		}
+	}
+	
+	private MenuResult _menuResult;
+	
+    /**
+     * Constructor.
+     * @param id the of the action.
+     * @param menu the Submenu that knows about this MenuItem.
+     */
+    protected ActionMenuItem(String id, Submenu menu)
+    {
+        super(id, menu);
+        _menuResult = MenuResult.None;
+    }
+    
+	/** 
+     * Get the menu item type.
+     * @return the menu item type.
+     */
+    public String getType()
+    {
+        return MenuItem.MENUITEM_ACTION;
+    }
+
+    /**
+     * Sets what to do with the menu when this action is selected
+     * @param result
+     */
+    public void setMenuResult(MenuResult result) {
+    	_menuResult = result;
+    	update();
+    }
+    
+    @Override
+    public String getData() {
+    	return super.getData() + " -menu_result " + _menuResult.val;
+    }
+    
+    /** 
+     * Construct a new ActionMenuItem.
+     * @param menu the Submenu that owns the menu item.
+     * @param text the menu text.
+     * @return a new ActionMenuItem.
+     */
+    public static ActionMenuItem construct(Submenu menu, String text)
+    {
+    	return construct(menu, text, MenuResult.None);
+    }
+    
+    /** 
+     * Construct a new ActionMenuItem.
+     * @param menu the Submenu that owns the menu item.
+     * @param text the menu text.
+     * @return a new ActionMenuItem.
+     */
+    public static ActionMenuItem construct(Submenu menu, String text, MenuResult result)
+    {
+        ActionMenuItem menuItem = null;
+
+        try
+        {
+            menuItem = (ActionMenuItem)menu.constructMenuItem(MenuItem.MENUITEM_ACTION);
+            menuItem.setMenuResult(result);
+            menuItem.setText(text);
+        }
+        catch (LCDException e) //NOPMD
+        {
+            // Supress, would only get one if we asked for an invalid menu item.
+        }
+
+        return menuItem;
+    }
+    
+    /**
+     * Adds an ActionListener to the menu item.
+     * @param listener the ActionListener to be added
+     */
+	public void addActionListener(ActionListener listener) {
+		_listeners.add(ActionListener.class, listener);
+	}
+
+	/**
+	 * Removes an ActionListener from the menu item.
+	 * @param listener the ActionListener to be removed
+	 */
+	public void removeActionListener(ActionListener listener) {
+		_listeners.remove(ActionListener.class, listener);
+	}
+    
+    public void notifyActionPerformed(ActionEvent e) {
+		for (ActionListener l : _listeners.getListeners(ActionListener.class)) {
+			l.actionPerformed(e);
+		}
+    }
+}
+

--- a/src/org/boncey/lcdjava/AlphaMenuItem.java
+++ b/src/org/boncey/lcdjava/AlphaMenuItem.java
@@ -1,0 +1,194 @@
+package org.boncey.lcdjava;
+
+
+
+
+/**
+ * AlphaMenuItem.
+ * <p>Is visible as a text. When selected, a screen comes up that shows the 
+ * current string value, that you can edit with the cursor keys and Enter. 
+ * The string is ended by selecting a 'null' input character. After that the 
+ * menu returns. 
+ * @author StefanKrupop
+ */
+public class AlphaMenuItem extends AbstractMenuItem 
+{
+	private String _value;
+	private int _minlength;
+	private int _maxlength;
+	private String _passwordchar;
+	private boolean _allowCaps;
+	private boolean _allowNonCaps;
+	private boolean _allowNumbers;
+	private String _allowedExtra;
+	
+    /**
+     * Constructor.
+     * @param id the of the action.
+     * @param menu the Submenu that knows about this MenuItem.
+     */
+    protected AlphaMenuItem(String id, Submenu menu)
+    {
+        super(id, menu);
+        _value = "";
+        _minlength = 0;
+        _maxlength = 10;
+        _passwordchar = "";
+        _allowCaps = true;
+        _allowNonCaps = true;
+        _allowNumbers = true;
+        _allowedExtra = "";
+    }
+    
+	/** 
+     * Get the menu item type.
+     * @return the menu item type.
+     */
+    public String getType()
+    {
+        return MenuItem.MENUITEM_ALPHA;
+    }
+    
+    /**
+     * Sets current value of the entry
+     * @param value current value 
+     */
+    public void setValue(String value) {
+    	_value = value;    			
+    	update();
+    }
+    
+    /**
+     * Sets current value of the entry but does not send the change to LCDd
+     * @param value current value
+     */
+    public void setValueNoUpdate(String value) {
+   		_value = value;
+    }
+    
+    /**
+     * Gets the currently set value
+     * @return value current value
+     */
+    public String getValue() {
+    	return _value;
+    }
+
+    /**
+     * Sets the minimum length of the string that can be entered
+     * @param value min length 
+     */
+    public void setMinLength(int value) {
+    	_minlength = value;    			
+    	update();
+    }
+
+    /**
+     * Sets the maximum length of the string that can be entered
+     * @param value max length 
+     */
+    public void setMaxLength(int value) {
+    	_maxlength = value;    			
+    	update();
+    }
+
+    /**
+     * Sets the character that should be displayed instead of typed characters
+     * @param value password character 
+     */
+    public void setPasswordChar(String value) {
+    	_passwordchar = value; 			
+    	update();
+    }
+
+    /**
+     * Sets if upper case characters can be entered
+     * @param value new state
+     */
+    public void setAllowCaps(boolean value) {
+    	_allowCaps = value; 			
+    	update();
+    }
+
+    /**
+     * Sets if lower case characters can be entered
+     * @param value new state
+     */
+    public void setAllowNonCaps(boolean value) {
+    	_allowNonCaps = value; 			
+    	update();
+    }
+    
+    /**
+     * Sets if numbers can be entered
+     * @param value new state
+     */
+    public void setAllowNumbers(boolean value) {
+    	_allowNumbers = value; 			
+    	update();
+    }
+
+    /**
+     * Sets additional characters that can be entered
+     * @param chars allowed characters
+     */
+    public void setAllowExtra(String chars) {
+    	_allowedExtra = chars;
+    	update();
+    }
+    
+    @Override
+    public String getData() {
+    	StringBuilder strb = new StringBuilder();
+    	strb.append(super.getData());
+    	strb.append(" -value \"");
+    	strb.append(_value);
+    	strb.append("\" -minlength ");
+    	strb.append(_minlength);
+    	strb.append(" -maxlength ");
+    	strb.append(_maxlength);
+    	if (!_passwordchar.isEmpty()) {
+    		strb.append(" -password_char \"");
+    		strb.append(_passwordchar);
+    		strb.append('"');
+    	}
+    	strb.append(" -allow_caps ");
+    	strb.append(_allowCaps ? "true" : "false");
+    	strb.append(" -allow_noncaps ");
+    	strb.append(_allowNonCaps ? "true" : "false");
+    	strb.append(" -allow_numbers ");
+    	strb.append(_allowNumbers ? "true" : "false");
+    	if (!_allowedExtra.isEmpty()) {
+    		strb.append(" -allowed_extra \"");
+    		strb.append(_allowedExtra);
+    		strb.append('"');
+    	}
+    	
+    	return strb.toString();
+    }
+
+    /** 
+     * Construct a new AlphaMenuItem.
+     * @param menu the Submenu that owns the menu item.
+     * @param text the menu text.
+     * @param current the current string
+     * @return a new AlphaMenuItem.
+     */
+    public static AlphaMenuItem construct(Submenu menu, String text, String current)
+    {
+        AlphaMenuItem menuItem = null;
+
+        try
+        {
+            menuItem = (AlphaMenuItem)menu.constructMenuItem(MenuItem.MENUITEM_ALPHA);
+            menuItem.setValue(current);
+            menuItem.setText(text);
+        }
+        catch (LCDException e) //NOPMD
+        {
+            // Supress, would only get one if we asked for an invalid menu item.
+        }
+
+        return menuItem;
+    }
+}

--- a/src/org/boncey/lcdjava/CheckboxMenuItem.java
+++ b/src/org/boncey/lcdjava/CheckboxMenuItem.java
@@ -1,0 +1,140 @@
+package org.boncey.lcdjava;
+
+
+
+
+/**
+ * CheckboxnMenuItem.
+ * <p>Item to display a slectable status indicator
+ * @author StefanKrupop
+ */
+public class CheckboxMenuItem extends AbstractMenuItem 
+{
+	public enum CheckboxValue {
+		/**
+		 * Off
+		 */
+		Off("off"),
+		/**
+		 * On
+		 */
+		On("on"),
+		/**
+		 * Grayed out
+		 */
+		Gray("gray");
+		
+		public String val;
+		
+		CheckboxValue(String val) {
+			this.val = val;
+		}
+	}
+	
+	private CheckboxValue _value;
+	private boolean _allowGray;
+	
+    /**
+     * Constructor.
+     * @param id the of the action.
+     * @param menu the Submenu that knows about this MenuItem.
+     */
+    protected CheckboxMenuItem(String id, Submenu menu)
+    {
+        super(id, menu);
+        _allowGray = false;
+        _value = CheckboxValue.Off;
+    }
+    
+	/** 
+     * Get the menu item type.
+     * @return the menu item type.
+     */
+    public String getType()
+    {
+        return MenuItem.MENUITEM_CHECKBOX;
+    }
+
+    /**
+     * Sets if a grayed checkbox is allowed
+     * @param allowGray whether grayed checkbox is allowed
+     */
+    public void setAllowGray(boolean allowGray) {
+    	_allowGray = allowGray;
+    	update();
+    }
+
+    /**
+     * Sets current value of a checkbox
+     * @param value current status 
+     */
+    public void setValue(CheckboxValue value) {
+    	_value = value;
+    	update();
+    }
+    
+    /**
+     * Sets current value of a checkbox but does not send the change to LCDd
+     * @param value current status
+     */
+    public void setValueNoUpdate(CheckboxValue value) {
+    	_value = value;
+    }
+    
+    /**
+     * Gets the current status of the checkbox
+     * @return status of the checkbox
+     */
+    public CheckboxValue getValue() {
+    	return _value;
+    }
+    
+    /**
+     * Gets the current status of the checkbox
+     * @return whether the checkbox is On
+     */
+    public boolean isSelected() {
+    	return _value.equals(CheckboxValue.On);
+    }
+    
+    @Override
+    public String getData() {
+    	return super.getData() + " -value " + _value.val + " -allow_gray " + (_allowGray ? "true" : "false");
+    }
+    
+    /** 
+     * Construct a new CheckboxMenuItem.
+     * @param menu the Submenu that owns the menu item.
+     * @param text the menu text.
+     * @return a new ActionMenuItem.
+     */
+    public static CheckboxMenuItem construct(Submenu menu, String text)
+    {
+    	return construct(menu, text, false);
+    }
+    
+    /** 
+     * Construct a new ActionMenuItem.
+     * @param menu the Submenu that owns the menu item.
+     * @param text the menu text.
+     * @return a new ActionMenuItem.
+     */
+    public static CheckboxMenuItem construct(Submenu menu, String text, boolean allowGray)
+    {
+        CheckboxMenuItem menuItem = null;
+
+        try
+        {
+            menuItem = (CheckboxMenuItem)menu.constructMenuItem(MenuItem.MENUITEM_CHECKBOX);
+            menuItem.setAllowGray(allowGray);
+            menuItem.setText(text);
+        }
+        catch (LCDException e) //NOPMD
+        {
+            // Supress, would only get one if we asked for an invalid menu item.
+        }
+
+        return menuItem;
+    }
+}
+

--- a/src/org/boncey/lcdjava/CheckboxMenuItem.java
+++ b/src/org/boncey/lcdjava/CheckboxMenuItem.java
@@ -117,6 +117,7 @@ public class CheckboxMenuItem extends AbstractMenuItem
      * Construct a new ActionMenuItem.
      * @param menu the Submenu that owns the menu item.
      * @param text the menu text.
+     * @param allowGray whether the "Gray" state is allowed
      * @return a new ActionMenuItem.
      */
     public static CheckboxMenuItem construct(Submenu menu, String text, boolean allowGray)

--- a/src/org/boncey/lcdjava/IpMenuItem.java
+++ b/src/org/boncey/lcdjava/IpMenuItem.java
@@ -1,0 +1,109 @@
+package org.boncey.lcdjava;
+
+
+
+
+/**
+ * IpMenuItem.
+ * <p>Allows the user to input an IP number (v4 or v6). When selected, a 
+ * screen comes up that shows an IP number that can be edited - digit by digit 
+ * - via left/right (switch digit) and up/down keys (increase/decrease). 
+ * @author StefanKrupop
+ */
+public class IpMenuItem extends AbstractMenuItem 
+{
+	private String _value;
+	private boolean _v6;
+	
+    /**
+     * Constructor.
+     * @param id the of the action.
+     * @param menu the Submenu that knows about this MenuItem.
+     */
+    protected IpMenuItem(String id, Submenu menu)
+    {
+        super(id, menu);
+        _value = "";
+        _v6 = false;
+    }
+    
+	/** 
+     * Get the menu item type.
+     * @return the menu item type.
+     */
+    public String getType()
+    {
+        return MenuItem.MENUITEM_IP;
+    }
+    
+    /**
+     * Sets current value of the entry
+     * @param value current value 
+     */
+    public void setValue(String value) {
+    	_value = value;    			
+    	update();
+    }
+    
+    /**
+     * Sets current value of the entry but does not send the change to LCDd
+     * @param value current value
+     */
+    public void setValueNoUpdate(String value) {
+   		_value = value;
+    }
+    
+    /**
+     * Gets the currently set ip
+     * @return value IP in string format
+     */
+    public String getValue() {
+    	return _value;
+    }
+
+    /**
+     * Sets if this entry is for v6 IP addresses
+     * @param isV6 current value
+     */
+    public void setV6(boolean isV6) {
+    	_v6 = isV6;    			
+    	update();
+    }
+
+    @Override
+    public String getData() {
+    	StringBuilder strb = new StringBuilder();
+    	strb.append(super.getData());
+    	strb.append(" -value \"");
+    	strb.append(_value);
+    	strb.append("\" -v6 ");
+    	strb.append(_v6 ? "true" : "false");
+    	
+    	return strb.toString();
+    }
+
+    /** 
+     * Construct a new IpMenuItem.
+     * @param menu the Submenu that owns the menu item.
+     * @param text the menu text.
+     * @param current the current IP
+     * @return a new IpMenuItem.
+     */
+    public static IpMenuItem construct(Submenu menu, String text, String current)
+    {
+        IpMenuItem menuItem = null;
+
+        try
+        {
+            menuItem = (IpMenuItem)menu.constructMenuItem(MenuItem.MENUITEM_IP);
+            menuItem.setValue(current);
+            menuItem.setText(text);
+        }
+        catch (LCDException e) //NOPMD
+        {
+            // Supress, would only get one if we asked for an invalid menu item.
+        }
+
+        return menuItem;
+    }
+}

--- a/src/org/boncey/lcdjava/LCDListener.java
+++ b/src/org/boncey/lcdjava/LCDListener.java
@@ -1,7 +1,7 @@
 package org.boncey.lcdjava;
 
 /**
- * Interface for listening to the state of a Screen.
+ * Interface for listening to the state returned from LCDd.
  * <p>Copyright (c) 2004-2005 Darren Greaves.
  * @author Darren Greaves
  * @version $Id: LCDListener.java,v 1.2 2005-03-03 14:13:16 boncey Exp $
@@ -21,5 +21,13 @@ public interface LCDListener
      * <code>false</code> if not.
      */
     public void setListenStatus(int screenId, boolean listening);
+
+    /** 
+     * The user interacted with a menu
+     * @param menuId the id of the menu item.
+     * @param eventType the type of the event that occured
+     * @param value the value returned or <code>null</code>when not available
+     */
+	public void menuAction(String menuId, String eventType, String value);
 }
 

--- a/src/org/boncey/lcdjava/MenuItem.java
+++ b/src/org/boncey/lcdjava/MenuItem.java
@@ -1,0 +1,78 @@
+package org.boncey.lcdjava;
+
+
+/**
+ * Interface for menu items.
+ * @author Stefan Krupop
+ */
+public interface MenuItem
+{
+    /** 
+     * The name of the action item.
+     */
+    public static final String MENUITEM_ACTION = "action";
+
+    /** 
+     * The name of the checkbox item.
+     */
+    public static final String MENUITEM_CHECKBOX = "checkbox";
+
+    /** 
+     * The name of the ring item.
+     */
+    public static final String MENUITEM_RING = "ring";
+
+    /** 
+     * The name of the slider item.
+     */
+    public static final String MENUITEM_SLIDER = "slider";
+
+    /** 
+     * The name of the numeric item.
+     */
+    public static final String MENUITEM_NUMERIC = "numeric";
+
+    /** 
+     * The name of the alpha item.
+     */
+    public static final String MENUITEM_ALPHA = "alpha";
+
+    /** 
+     * The name of the IP item.
+     */
+    public static final String MENUITEM_IP = "ip";
+
+    /** 
+     * The name of the menu item.
+     */
+    public static final String MENUITEM_MENU = "menu";
+
+    /** 
+     * Get the menu id.
+     * @return the menu id.
+     */
+    public String getID();
+
+    /** 
+     * Get the menu type.
+     * @return the menu type.
+     */
+    public String getType();
+
+    /** 
+     * Return the data this item needs to update itself.
+     * @return the data to update this item.
+     */
+    public String getData();
+
+    /** 
+     * Add this item to the Menu.
+     * @return whether or not the item was added successfully.
+     */
+    public boolean activate();
+
+    /** 
+     * Remove this item.
+     */
+    public void remove();
+}

--- a/src/org/boncey/lcdjava/NumericMenuItem.java
+++ b/src/org/boncey/lcdjava/NumericMenuItem.java
@@ -1,0 +1,149 @@
+package org.boncey.lcdjava;
+
+
+
+
+/**
+ * NumericMenuItem.
+ * <p>Allows the user to input an integer value. Is visible as a text. When 
+ * selected, a screen comes up that shows the current numeric value, that you 
+ * can edit with the cursor keys and Enter. The number is ended by selecting 
+ * a 'null' input digit. After that the menu returns. 
+ * @author StefanKrupop
+ */
+public class NumericMenuItem extends AbstractMenuItem 
+{
+	private int _value;
+	private int _minvalue;
+	private int _maxvalue;
+	
+    /**
+     * Constructor.
+     * @param id the of the action.
+     * @param menu the Submenu that knows about this MenuItem.
+     */
+    protected NumericMenuItem(String id, Submenu menu)
+    {
+        super(id, menu);
+        _value = 0;
+        _minvalue = 0;
+        _maxvalue = 100;
+    }
+    
+	/** 
+     * Get the menu item type.
+     * @return the menu item type.
+     */
+    public String getType()
+    {
+        return MenuItem.MENUITEM_NUMERIC;
+    }
+    
+    /**
+     * Sets current value of the entry
+     * @param value current value 
+     */
+    public void setValue(int value) {
+    	if (value >= _minvalue && value <= _maxvalue) {
+    		_value = value;    			
+    		update();
+    	}
+    }
+    
+    /**
+     * Sets current value of the entry but does not send the change to LCDd
+     * @param value current value
+     */
+    public void setValueNoUpdate(int value) {
+    	if (value >= _minvalue && value <= _maxvalue) {
+    		_value = value;    			
+    	}
+    }
+    
+    /**
+     * Gets the current value of the entry
+     * @return value of the entry
+     */
+    public int getValue() {
+    	return _value;
+    }
+    
+    /**
+     * Sets minimum value of the entry
+     * @param value min value 
+     */
+    public void setMinValue(int value) {
+    	_minvalue = value;
+    	if (_value < _minvalue) {
+    		_value = _minvalue;
+    	}
+    	if (_minvalue <= _maxvalue) {
+    		update();
+    	}
+    }
+    
+    /**
+     * Sets maximum value of the entry
+     * @param value max value 
+     */
+    public void setMaxValue(int value) {
+    	_maxvalue = value;
+    	if (_value > _maxvalue) {
+    		_value = _maxvalue;
+    	}
+    	if (_maxvalue >= _minvalue) {
+    		update();
+    	}
+    }
+
+    @Override
+    public String getData() {
+    	StringBuilder strb = new StringBuilder();
+    	strb.append(super.getData());
+    	strb.append(" -value ");
+    	strb.append(_value);
+    	strb.append(" -minvalue ");
+    	strb.append(_minvalue);
+    	strb.append(" -maxvalue ");
+    	strb.append(_maxvalue);
+    	return strb.toString();
+    }
+
+    /** 
+     * Construct a new NumericMenuItem.
+     * @param menu the Submenu that owns the menu item.
+     * @param text the menu text.
+     * @return a new NumericMenuItem.
+     */
+    public static NumericMenuItem construct(Submenu menu, String text)
+    {
+    	return construct(menu, text, 0, 100);
+	}
+    
+    /** 
+     * Construct a new NumericMenuItem.
+     * @param menu the Submenu that owns the menu item.
+     * @param text the menu text.
+     * @param minValue the minimum value of the entry
+     * @param maxValue the maximum value of the entry
+     * @return a new NumericMenuItem.
+     */
+    public static NumericMenuItem construct(Submenu menu, String text, int minValue, int maxValue)
+    {
+        NumericMenuItem menuItem = null;
+
+        try
+        {
+            menuItem = (NumericMenuItem)menu.constructMenuItem(MenuItem.MENUITEM_NUMERIC);
+            menuItem.setText(text);
+            menuItem.setMinValue(minValue);
+            menuItem.setMaxValue(maxValue);
+        }
+        catch (LCDException e) //NOPMD
+        {
+            // Supress, would only get one if we asked for an invalid menu item.
+        }
+
+        return menuItem;
+    }
+}

--- a/src/org/boncey/lcdjava/RingMenuItem.java
+++ b/src/org/boncey/lcdjava/RingMenuItem.java
@@ -1,0 +1,134 @@
+package org.boncey.lcdjava;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+
+
+/**
+ * RingMenuItem.
+ * <p>Item to display a text and a status indicator.
+ * The status can be one of the strings specified for the item. 
+ * @author StefanKrupop
+ */
+public class RingMenuItem extends AbstractMenuItem 
+{
+	private int _value;
+	private List<String> _items;
+	
+    /**
+     * Constructor.
+     * @param id the of the action.
+     * @param menu the Submenu that knows about this MenuItem.
+     */
+    protected RingMenuItem(String id, Submenu menu)
+    {
+        super(id, menu);
+        _items = new ArrayList<String>();
+        _value = 0;
+    }
+    
+	/** 
+     * Get the menu item type.
+     * @return the menu item type.
+     */
+    public String getType()
+    {
+        return MenuItem.MENUITEM_RING;
+    }
+    
+    public void setItems(List<String> items) {
+    	_items = items;
+    	_value = 0;
+    	update();
+    }
+
+    /**
+     * Sets current value of the ring
+     * @param value current value 
+     */
+    public void setValue(String value) {
+    	for (int i = 0; i < _items.size(); ++i) {
+    		if (value.equals(_items.get(i))) {
+    	    	_value = i;    			
+    		}
+    	}
+    	update();
+    }
+    
+    /**
+     * Sets current value of the ring but does not send the change to LCDd
+     * @param value current value
+     */
+    public void setValueNoUpdate(int value) {
+    	if (value >= 0 && value < _items.size()) {
+    		_value = value;
+    	}
+    }
+    
+    /**
+     * Gets the current value of the ring
+     * @return value of the ring
+     */
+    public String getValue() {
+    	return _items.get(_value);
+    }
+        
+    @Override
+    public String getData() {
+    	StringBuilder strb = new StringBuilder();
+    	strb.append(super.getData());
+    	strb.append(" -value ");
+    	strb.append(_value);
+    	strb.append(" -strings \"");
+    	boolean first = true;
+    	for (String item : _items) {
+    		if (!first) {
+    			strb.append('\t');
+    		}
+    		strb.append(item);
+    		first = false;
+    	}
+    	strb.append('"');
+    	
+    	return strb.toString();
+    }
+
+    /** 
+     * Construct a new RingMenuItem.
+     * @param menu the Submenu that owns the menu item.
+     * @param text the menu text.
+     * @param items the items in the ring
+     * @return a new RingMenuItem.
+     */
+    public static RingMenuItem construct(Submenu menu, String text, String... items)
+    {
+    	return construct(menu, text, Arrays.asList(items));
+    }
+    
+    /** 
+     * Construct a new RingMenuItem.
+     * @param menu the Submenu that owns the menu item.
+     * @param text the menu text.
+     * @param items the items in the ring
+     * @return a new RingMenuItem.
+     */
+    public static RingMenuItem construct(Submenu menu, String text, List<String> items)
+    {
+        RingMenuItem menuItem = null;
+
+        try
+        {
+            menuItem = (RingMenuItem)menu.constructMenuItem(MenuItem.MENUITEM_RING);
+            menuItem.setItems(items);
+            menuItem.setText(text);
+        }
+        catch (LCDException e) //NOPMD
+        {
+            // Supress, would only get one if we asked for an invalid menu item.
+        }
+
+        return menuItem;
+    }
+}

--- a/src/org/boncey/lcdjava/SliderMenuItem.java
+++ b/src/org/boncey/lcdjava/SliderMenuItem.java
@@ -1,0 +1,124 @@
+package org.boncey.lcdjava;
+
+
+
+
+/**
+ * SliderMenuItem.
+ * <p>Is visible as a text. When selected, a screen comes up that shows a
+ * slider. You can set the slider using the cursor keys. When Enter is 
+ * pressed, the menu returns. 
+ * @author StefanKrupop
+ */
+public class SliderMenuItem extends NumericMenuItem 
+{
+	private String _mintext;
+	private String _maxtext;
+	private int _stepsize;
+	
+    /**
+     * Constructor.
+     * @param id the of the action.
+     * @param menu the Submenu that knows about this MenuItem.
+     */
+    protected SliderMenuItem(String id, Submenu menu)
+    {
+        super(id, menu);
+        _mintext = "";
+        _maxtext = "";
+        _stepsize = 1;
+    }
+    
+	/** 
+     * Get the menu item type.
+     * @return the menu item type.
+     */
+    public String getType()
+    {
+        return MenuItem.MENUITEM_SLIDER;
+    }
+    
+    /**
+     * Sets label for minimum value of the slider
+     * @param value text to be shown on left side of slider 
+     */
+    public void setMinText(String value) {
+    	_mintext = value;
+    	update();
+    }
+
+    /**
+     * Sets label for maximum value of the slider
+     * @param value text to be shown on right side of slider 
+     */
+    public void setMaxText(String value) {
+    	_maxtext = value;
+    	update();
+    }
+
+    /**
+     * Sets step size of the slider
+     * @param size step size 
+     */
+    public void setStepSize(int size) {
+    	_stepsize = size;
+   		update();
+    }
+
+    @Override
+    public String getData() {
+    	StringBuilder strb = new StringBuilder();
+    	strb.append(super.getData());
+    	strb.append(" -stepsize ");
+    	strb.append(_stepsize);
+    	if (!_mintext.isEmpty()) {
+        	strb.append(" -mintext \"");
+        	strb.append(_mintext);
+        	strb.append('"');
+    	}
+    	if (!_maxtext.isEmpty()) {
+        	strb.append(" -maxtext \"");
+        	strb.append(_maxtext);
+        	strb.append('"');
+    	}
+    	return strb.toString();
+    }
+
+    /** 
+     * Construct a new SliderMenuItem.
+     * @param menu the Submenu that owns the menu item.
+     * @param text the menu text.
+     * @return a new SliderMenuItem.
+     */
+    public static SliderMenuItem construct(Submenu menu, String text)
+    {
+    	return construct(menu, text, 0, 100);
+	}
+    
+    /** 
+     * Construct a new SliderMenuItem.
+     * @param menu the Submenu that owns the menu item.
+     * @param text the menu text.
+     * @param minValue the minimum value of the slider
+     * @param maxValue the maximum value of the slider
+     * @return a new SliderMenuItem.
+     */
+    public static SliderMenuItem construct(Submenu menu, String text, int minValue, int maxValue)
+    {
+        SliderMenuItem menuItem = null;
+
+        try
+        {
+            menuItem = (SliderMenuItem)menu.constructMenuItem(MenuItem.MENUITEM_SLIDER);
+            menuItem.setText(text);
+            menuItem.setMinValue(minValue);
+            menuItem.setMaxValue(maxValue);
+        }
+        catch (LCDException e) //NOPMD
+        {
+            // Supress, would only get one if we asked for an invalid menu item.
+        }
+
+        return menuItem;
+    }
+}

--- a/src/org/boncey/lcdjava/Submenu.java
+++ b/src/org/boncey/lcdjava/Submenu.java
@@ -1,0 +1,214 @@
+package org.boncey.lcdjava;
+
+import java.util.HashMap;
+import java.util.Map;
+
+
+/**
+ * Submenu.
+ * <p>Displays the submenus name with tailing ">"
+ * @author StefanKrupop
+ */
+public class Submenu extends AbstractMenuItem 
+{
+    /** 
+     * The LCD that owns this Submenu.
+     */
+    private LCD _lcd;
+    
+    /** 
+     * A Map of MenuItems added to this Submenu.
+     */
+    private Map<String, MenuItem> _menuItems;
+    
+    /** 
+     * The count of menu items we have created.
+     */
+    private int _menuItemCounter;
+    
+    /**
+     * Constructor.
+     * @param lcd the LCD server object.
+     * @param id the of the submenu.
+     * @param menu the Submenu that knows about this MenuItem.
+     */
+    protected Submenu(LCD lcd, String id, Submenu menu)
+    {
+        super(id, menu);
+        _lcd = lcd;
+        _menuItems = new HashMap<String, MenuItem>();
+    }
+
+	public Submenu(LCD lcd) {
+		this(lcd, "", null);
+		_menu = this;
+	}
+
+	/** 
+     * Get the menu item type.
+     * @return the menu item type.
+     */
+    public String getType()
+    {
+        return MenuItem.MENUITEM_MENU;
+    }
+
+    /** 
+     * Construct a new Submenu.
+     * @param menu the Submenu that owns the submenu.
+     * @param text the menu text.
+     * @return a new Submenu.
+     */
+    public static Submenu construct(Submenu menu, String text)
+    {
+        Submenu menuItem = null;
+
+        try
+        {
+            menuItem = (Submenu)menu.constructMenuItem(MenuItem.MENUITEM_MENU);
+            menuItem.setText(text);
+        }
+        catch (LCDException e) //NOPMD
+        {
+            // Supress, would only get one if we asked for an invalid menu item.
+        }
+
+        return menuItem;
+    }
+
+    /** 
+     * Create a MenuItem for this Submenu.
+     * @param type the menu item type, see {@link MenuItem} for a list of types.
+     * @return the created MenuItem.
+     * @throws LCDException if the menu item type is not recognized.
+     */
+    public MenuItem constructMenuItem(String type)
+        throws LCDException
+    {
+        MenuItem item = null;
+
+        synchronized (this) {
+	        if (type.equals(MenuItem.MENUITEM_MENU))
+	        {
+	            item = new Submenu(_lcd, getID() + "_" + Integer.toString(_menuItemCounter), this);
+	        }
+	        else if (type.equals(MenuItem.MENUITEM_ACTION))
+	        {
+	            item = new ActionMenuItem(getID() + "_" + Integer.toString(_menuItemCounter), this);
+	        }
+	        else if (type.equals(MenuItem.MENUITEM_CHECKBOX))
+	        {
+	        	item = new CheckboxMenuItem(getID() + "_" + Integer.toString(_menuItemCounter), this);
+	        }
+	        else if (type.equals(MenuItem.MENUITEM_RING))
+	        {
+	        	item = new RingMenuItem(getID() + "_" + Integer.toString(_menuItemCounter), this);
+	        }
+	        else if (type.equals(MenuItem.MENUITEM_SLIDER))
+	        {
+	        	item = new SliderMenuItem(getID() + "_" + Integer.toString(_menuItemCounter), this);
+	        }
+	        else if (type.equals(MenuItem.MENUITEM_NUMERIC))
+	        {
+	        	item = new NumericMenuItem(getID() + "_" + Integer.toString(_menuItemCounter), this);
+	        }
+	        else if (type.equals(MenuItem.MENUITEM_ALPHA))
+	        {
+	        	item = new AlphaMenuItem(getID() + "_" + Integer.toString(_menuItemCounter), this);
+	        }
+	        else if (type.equals(MenuItem.MENUITEM_IP))
+	        {
+	        	item = new IpMenuItem(getID() + "_" + Integer.toString(_menuItemCounter), this);
+	        }
+	        else
+	        {
+	            throw new LCDException(
+	                    "Unable to create a menu item of type " + type);
+	        }
+	        
+	        _menuItemCounter++;
+        }
+
+        return item;
+    }
+
+    /** 
+     * Add a MenuItem to this Submenu.
+     * @param item the MenuItem to add.
+     * @return whether or not the menu item was added successfully.
+     */
+    protected boolean addItem(MenuItem item)
+    {
+        boolean success = false;
+
+        String itemId = item.getID();
+        synchronized (this) {
+	        if (!_menuItems.containsKey(itemId))
+	        {
+	            _menuItems.put(itemId, item);
+	            _lcd.write(LCD.CMD_MENU_ADD + "\"" + _id + "\"" + " " + itemId +
+	                       " " + item.getType() + " \"\"");
+	            success = updateItem(item);
+	        }
+        }
+
+        return success;
+    }
+	
+    /** 
+     * Update a MenuItem on this Submenu.
+     * @param item the MenuItem to update.
+     * @return whether or not the MenuItem was updated successfully.
+     */
+    protected boolean updateItem(MenuItem item)
+    {
+        boolean success = false;
+
+        String itemId = item.getID();
+        synchronized (this) {
+	        if (_menuItems.containsKey(itemId))
+	        {
+	            _lcd.write(LCD.CMD_MENU_SET + "\"" + _id + "\"" + " " + itemId +
+	                       " " + item.getData());
+	            success = true;
+	        }
+        }
+
+        return success;
+    }
+    
+    /** 
+     * Delete a MenuItem from this Submenu.
+     * @param item the MenuItem to delete.
+     */
+    protected void removeItem(MenuItem item)
+    {
+        String itemId = item.getID();
+        synchronized (this) {
+	        if (_menuItems.containsKey(itemId))
+	        {
+	            _lcd.write(LCD.CMD_MENU_DEL + "\"" + _id + "\"" + " " + itemId);
+	            _menuItems.remove(itemId);
+	        }
+        }
+    }
+
+    /**
+     * Return menu item with the given id
+     * @param id the id of the menu item
+     * @return the MenuItem or null when the ID does not exist
+     */
+	public MenuItem getMenuItem(String id) {
+		return _menuItems.get(id);
+	}
+    
+    /**
+     * Sets this menu as the current main menu
+     */
+	public void setAsMainMenu() {
+        synchronized (this) {
+            _lcd.write(LCD.CMD_MENU_SET_MAIN + "\"" + _id + "\"");
+        }
+	}
+}
+

--- a/src/org/boncey/lcdjava/Submenu.java
+++ b/src/org/boncey/lcdjava/Submenu.java
@@ -6,7 +6,7 @@ import java.util.Map;
 
 /**
  * Submenu.
- * <p>Displays the submenus name with tailing ">"
+ * <p>Displays the submenus name with tailing submenu marker
  * @author StefanKrupop
  */
 public class Submenu extends AbstractMenuItem 


### PR DESCRIPTION
This adds support for LCDd's menu system. Menu items support ActionListeners to be called when they are executed or change value.

Sample usage:

``` java
        Submenu mainMenu = Submenu.construct(mLCD.getRootMenu(), "Main menu");
        mainMenu.activate();        

        SliderMenuItem slider = SliderMenuItem.construct(mainMenu, "Slider", 1, 18);
        slider.addActionListener(new ActionListener() {
            @Override
            public void actionPerformed(ActionEvent e) {
                mLog.debug("Slider changed. Value=" + ((SliderMenuItem)e.getSource()).getValue());
            }
        });
        slider.activate();

        Submenu shutdownMenu = Submenu.construct(mainMenu, "Shutdown");
        shutdownMenu.activate();
        ActionMenuItem.construct(shutdownMenu, "Cancel", MenuResult.Close).activate();
        ActionMenuItem shutdown = ActionMenuItem.construct(shutdownMenu, "OK", MenuResult.Quit);
        shutdown.activate();
        shutdown.addActionListener(new ActionListener() {
            @Override
            public void actionPerformed(ActionEvent e) {
                System.out.println("Power off!");
            }
        });

        ActionMenuItem.construct(mainMenu, "Exit", MenuResult.Quit).activate();
        mainMenu.setAsMainMenu();
```
